### PR TITLE
Add reproducible conda package build

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -1,0 +1,64 @@
+name: Conda package
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: conda-build
+          auto-update-conda: true
+          channels: conda-forge
+          channel-priority: strict
+          miniforge-version: latest
+
+      - name: Install build tools
+        shell: bash -el {0}
+        run: conda install --yes conda-build anaconda-client
+
+      - name: Build and test package
+        shell: bash -el {0}
+        run: conda build conda-recipe -c conda-forge --no-anaconda-upload
+
+      - name: Collect package
+        shell: bash -el {0}
+        run: |
+          mkdir -p conda-artifacts
+          package_path="$(conda build conda-recipe --output)"
+          cp "${package_path}" conda-artifacts/
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: autosolvate-conda-package
+          path: conda-artifacts/*
+
+      - name: Upload tagged release to Anaconda.org
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash -el {0}
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        run: |
+          if [[ -z "${ANACONDA_API_TOKEN}" ]]; then
+            echo "::warning::ANACONDA_API_TOKEN is not configured; skipping release upload."
+            exit 0
+          fi
+          anaconda --token "${ANACONDA_API_TOKEN}" upload --force conda-artifacts/*

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -37,15 +37,15 @@ jobs:
       - name: Build and test package
         shell: bash -el {0}
         run: |
-          conda run --name conda-build conda build conda-recipe/molsimplify -c conda-forge --no-anaconda-upload
-          conda run --name conda-build conda build conda-recipe -c local -c conda-forge --no-anaconda-upload
+          conda run --name conda-build conda-build conda-recipe/molsimplify -c conda-forge --no-anaconda-upload
+          conda run --name conda-build conda-build conda-recipe -c local -c conda-forge --no-anaconda-upload
 
       - name: Collect package
         shell: bash -el {0}
         run: |
           mkdir -p conda-artifacts
-          molsimplify_path="$(conda run --name conda-build conda build conda-recipe/molsimplify -c conda-forge --output)"
-          autosolvate_path="$(conda run --name conda-build conda build conda-recipe -c local -c conda-forge --output)"
+          molsimplify_path="$(conda run --name conda-build conda-build conda-recipe/molsimplify -c conda-forge --output)"
+          autosolvate_path="$(conda run --name conda-build conda-build conda-recipe -c local -c conda-forge --output)"
           cp "${molsimplify_path}" "${autosolvate_path}" conda-artifacts/
 
       - name: Upload workflow artifact

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -32,20 +32,20 @@ jobs:
 
       - name: Install build tools
         shell: bash -el {0}
-        run: conda install --yes conda-build anaconda-client
+        run: conda install --yes --name conda-build conda-build anaconda-client
 
       - name: Build and test package
         shell: bash -el {0}
         run: |
-          conda build conda-recipe/molsimplify -c conda-forge --no-anaconda-upload
-          conda build conda-recipe -c local -c conda-forge --no-anaconda-upload
+          conda run --name conda-build conda build conda-recipe/molsimplify -c conda-forge --no-anaconda-upload
+          conda run --name conda-build conda build conda-recipe -c local -c conda-forge --no-anaconda-upload
 
       - name: Collect package
         shell: bash -el {0}
         run: |
           mkdir -p conda-artifacts
-          molsimplify_path="$(conda build conda-recipe/molsimplify -c conda-forge --output)"
-          autosolvate_path="$(conda build conda-recipe -c local -c conda-forge --output)"
+          molsimplify_path="$(conda run --name conda-build conda build conda-recipe/molsimplify -c conda-forge --output)"
+          autosolvate_path="$(conda run --name conda-build conda build conda-recipe -c local -c conda-forge --output)"
           cp "${molsimplify_path}" "${autosolvate_path}" conda-artifacts/
 
       - name: Upload workflow artifact

--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -36,14 +36,17 @@ jobs:
 
       - name: Build and test package
         shell: bash -el {0}
-        run: conda build conda-recipe -c conda-forge --no-anaconda-upload
+        run: |
+          conda build conda-recipe/molsimplify -c conda-forge --no-anaconda-upload
+          conda build conda-recipe -c local -c conda-forge --no-anaconda-upload
 
       - name: Collect package
         shell: bash -el {0}
         run: |
           mkdir -p conda-artifacts
-          package_path="$(conda build conda-recipe --output)"
-          cp "${package_path}" conda-artifacts/
+          molsimplify_path="$(conda build conda-recipe/molsimplify -c conda-forge --output)"
+          autosolvate_path="$(conda build conda-recipe -c local -c conda-forge --output)"
+          cp "${molsimplify_path}" "${autosolvate_path}" conda-artifacts/
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -38,6 +38,9 @@ jobs:
       shell: bash -l {0}
       run: conda activate autosolvate
 
+    - name: Complete source environment setup
+      run: conda run -n autosolvate bash devtools/scripts/post_autosolvate_env.sh
+
     - name: Install additional dependencies if needed
       run: conda install --yes flake8 pytest
 

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -21,25 +21,22 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Miniconda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
-        miniconda-version: "latest"
-        channels: anaconda
-        channel-priority: true
+        miniforge-version: "latest"
+        channels: conda-forge
+        channel-priority: strict
 
     - name: Create conda environment
-      run: conda env create -f devtools/conda-envs/environment.yml
+      run: conda env create -f devtools/conda-envs/test_env.yaml
 
     - name: Activate conda environment
       shell: bash -l {0}
       run: conda activate autosolvate
-
-    - name: Update pymsmt_autosolvate only
-      run:  pip install --upgrade --no-deps git+https://github.com/Liu-group/pymsmt_autosolvate.git
 
     - name: Install additional dependencies if needed
       run: conda install --yes flake8 pytest

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -10,7 +10,11 @@
 
 name: Autosolvate CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read

--- a/autosolvate/doctor.py
+++ b/autosolvate/doctor.py
@@ -1,0 +1,61 @@
+"""Validate the external runtime expected by an AutoSolvate conda environment."""
+
+from __future__ import annotations
+
+import os
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+def _check_environment() -> list[str]:
+    errors: list[str] = []
+    prefix_value = os.environ.get("CONDA_PREFIX")
+    if not prefix_value:
+        errors.append("CONDA_PREFIX is not set; activate the AutoSolvate conda environment.")
+        prefix = None
+    else:
+        prefix = Path(prefix_value)
+
+    babel_value = os.environ.get("BABEL_LIBDIR")
+    if not babel_value:
+        errors.append("BABEL_LIBDIR is not set; reactivate the conda environment.")
+    elif not Path(babel_value).is_dir():
+        errors.append(f"BABEL_LIBDIR does not exist: {babel_value}")
+    elif prefix and prefix not in Path(babel_value).parents:
+        errors.append(f"BABEL_LIBDIR is outside the active environment: {babel_value}")
+
+    try:
+        from openbabel import pybel  # noqa: F401
+    except Exception as exc:
+        errors.append(f"Open Babel Python/plugin import failed: {exc}")
+
+    try:
+        installed_version = version("molSimplify")
+    except PackageNotFoundError:
+        errors.append("molSimplify is not installed.")
+    else:
+        if installed_version != "1.8.0":
+            errors.append(
+                f"molSimplify 1.8.0 is required; found {installed_version}."
+            )
+
+    return errors
+
+
+def main() -> int:
+    errors = _check_environment()
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("AutoSolvate environment checks passed.")
+    print(f"  CONDA_PREFIX={os.environ['CONDA_PREFIX']}")
+    print(f"  BABEL_LIBDIR={os.environ['BABEL_LIBDIR']}")
+    print("  molSimplify=1.8.0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -1,0 +1,19 @@
+# AutoSolvate conda recipe
+
+Build the package from the repository root:
+
+```bash
+conda build conda-recipe -c conda-forge --no-anaconda-upload
+```
+
+Install the locally built package:
+
+```bash
+conda install -c local -c conda-forge autosolvate
+```
+
+The optional GUI and MCP integrations are not part of the base package. The MCP
+server can be enabled with `conda install -c conda-forge "fastmcp>=3,<4"`.
+
+The GitHub Actions workflow builds the package on every pull request. Tagged
+releases are uploaded when the `ANACONDA_API_TOKEN` repository secret is set.

--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -3,13 +3,25 @@
 Build the package from the repository root:
 
 ```bash
-conda build conda-recipe -c conda-forge --no-anaconda-upload
+conda build conda-recipe/molsimplify -c conda-forge --no-anaconda-upload
+conda build conda-recipe -c local -c conda-forge --no-anaconda-upload
 ```
 
 Install the locally built package:
 
 ```bash
 conda install -c local -c conda-forge autosolvate
+```
+
+The first recipe packages the exact molSimplify 1.8.0 compatibility version
+required by AutoSolvate. Unlike the source-install helper, it does not run pip
+after conda has finished or leave files that conda cannot track.
+
+The AutoSolvate package installs activation hooks that set `BABEL_LIBDIR` from
+the active environment. Validate an installation with:
+
+```bash
+autosolvate-doctor
 ```
 
 The optional GUI and MCP integrations are not part of the base package. The MCP

--- a/conda-recipe/activate.sh
+++ b/conda-recipe/activate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+if [ "${BABEL_LIBDIR+x}" = x ]; then
+    export AUTOSOLVATE_OLD_BABEL_LIBDIR="${BABEL_LIBDIR}"
+    export AUTOSOLVATE_HAD_BABEL_LIBDIR=1
+else
+    unset AUTOSOLVATE_OLD_BABEL_LIBDIR
+    unset AUTOSOLVATE_HAD_BABEL_LIBDIR
+fi
+
+for autosolvate_babel_dir in "${CONDA_PREFIX}"/lib/openbabel/*; do
+    if [ -d "${autosolvate_babel_dir}" ]; then
+        export BABEL_LIBDIR="${autosolvate_babel_dir}"
+        break
+    fi
+done
+unset autosolvate_babel_dir

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+"${PYTHON}" -m pip install . --no-deps --no-build-isolation -vv
+
+mkdir -p "${PREFIX}/etc/conda/activate.d"
+mkdir -p "${PREFIX}/etc/conda/deactivate.d"
+cp "${RECIPE_DIR}/activate.sh" \
+    "${PREFIX}/etc/conda/activate.d/autosolvate-openbabel.sh"
+cp "${RECIPE_DIR}/deactivate.sh" \
+    "${PREFIX}/etc/conda/deactivate.d/autosolvate-openbabel.sh"

--- a/conda-recipe/deactivate.sh
+++ b/conda-recipe/deactivate.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+if [ "${AUTOSOLVATE_HAD_BABEL_LIBDIR:-0}" = 1 ]; then
+    export BABEL_LIBDIR="${AUTOSOLVATE_OLD_BABEL_LIBDIR}"
+else
+    unset BABEL_LIBDIR
+fi
+
+unset AUTOSOLVATE_OLD_BABEL_LIBDIR
+unset AUTOSOLVATE_HAD_BABEL_LIBDIR

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -37,7 +37,6 @@ requirements:
     - parmed
     - pillow
     - pubchempy
-    - pytraj
     - python >=3.10,<3.13
     - rdkit
     - scipy <1.12
@@ -48,6 +47,7 @@ test:
   commands:
     - autosolvate --help
     - autosolvate-doctor
+    - python -c "import pytraj"
     - python -c "from autosolvate.ion_forcefield import IonForceFieldBuilder"
   requires:
     - pip

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,67 @@
+{% set version = "2.0.0rc1" %}
+
+package:
+  name: autosolvate
+  version: {{ version }}
+
+source:
+  path: ..
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - autosolvate = autosolvate.__main__:main
+    - autosolvate-mcp = autosolvate.fastmcp_server:main
+
+requirements:
+  host:
+    - pip
+    - python >=3.10,<3.13
+    - setuptools
+  run:
+    - ambertools
+    - ase
+    - basis_set_exchange
+    - mendeleev
+    - mdtraj
+    - molsimplify >=1.8
+    - networkx
+    - nglview
+    - numpy <2
+    - openbabel
+    - openmm
+    - packmol
+    - pandas
+    - parmed
+    - pillow
+    - pubchempy
+    - pytraj
+    - python >=3.10,<3.13
+    - rdkit
+    - scipy <1.12
+
+test:
+  imports:
+    - autosolvate
+  commands:
+    - autosolvate --help
+    - python -c "from autosolvate.ion_forcefield import IonForceFieldBuilder"
+  requires:
+    - pip
+
+about:
+  home: https://github.com/Liu-group/AutoSolvate
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: Automated workflow for adding explicit solvent to molecules
+  description: |
+    AutoSolvate automates the construction of explicitly solvated molecular
+    systems for classical and quantum chemistry workflows.
+  doc_url: https://autosolvate.readthedocs.io/
+  dev_url: https://github.com/Liu-group/AutoSolvate
+
+extra:
+  recipe-maintainers:
+    - Liu-group

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - autosolvate = autosolvate.__main__:main
+    - autosolvate-doctor = autosolvate.doctor:main
     - autosolvate-mcp = autosolvate.fastmcp_server:main
 
 requirements:
@@ -26,7 +26,7 @@ requirements:
     - basis_set_exchange
     - mendeleev
     - mdtraj
-    - molsimplify >=1.8
+    - autosolvate-molsimplify ==1.8.0
     - networkx
     - nglview
     - numpy <2
@@ -47,6 +47,7 @@ test:
     - autosolvate
   commands:
     - autosolvate --help
+    - autosolvate-doctor
     - python -c "from autosolvate.ion_forcefield import IonForceFieldBuilder"
   requires:
     - pip

--- a/conda-recipe/molsimplify/meta.yaml
+++ b/conda-recipe/molsimplify/meta.yaml
@@ -1,0 +1,51 @@
+{% set version = "1.8.0" %}
+
+package:
+  name: autosolvate-molsimplify
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/m/molsimplify/molsimplify-{{ version }}.tar.gz
+  sha256: b3b1fe16ae5fb760a1f656c49b9d48020f3e8fa1d2aed353fec7f6159f96868b
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.10,<3.13
+    - setuptools
+  run:
+    - importlib-resources
+    - networkx >=2.7
+    - numpy <2
+    - openbabel
+    - pandas
+    - python >=3.10,<3.13
+    - pyyaml
+    - scikit-learn
+    - scipy <1.12
+
+test:
+  imports:
+    - molSimplify
+    - molSimplify.Classes.mol3D
+  commands:
+    - python -c "from importlib.metadata import version; assert version('molSimplify') == '1.8.0'"
+
+about:
+  home: https://github.com/hjkgrp/molSimplify
+  license: GPL-3.0-only
+  license_file: LICENSE
+  summary: molSimplify 1.8.0 compatibility build for AutoSolvate
+  description: |
+    A pinned, conda-tracked build of molSimplify 1.8.0 used by AutoSolvate.
+    It replaces the untracked pip installation formerly performed after
+    creating an AutoSolvate environment.
+
+extra:
+  recipe-maintainers:
+    - Liu-group

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,9 @@ setup(
 
     # Additional entries you may want simply uncomment the lines you want and fill in the data
     # url='http://www.my_package.com',  # Website
-    install_requires=['imolecule'],              # Required packages, pulls from pip if needed; do not use for Conda deployment
+    install_requires=[],
     extras_require={
+        'gui': ['imolecule'],
         'mcp': ['fastmcp>=3.0,<4'],
     },
     # platforms=['Linux',

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     entry_points={
         'console_scripts': [
             'autosolvate = autosolvate.__main__:main',
+            'autosolvate-doctor = autosolvate.doctor:main',
             'autosolvate-mcp = autosolvate.fastmcp_server:main',
         ]
     },


### PR DESCRIPTION
## Summary

- add a maintained `conda-recipe/meta.yaml` with AutoSolvate runtime dependencies and import/CLI tests
- add a GitHub Actions workflow that builds a conda artifact for pull requests and main, and optionally uploads tagged releases to Anaconda.org
- fix the existing CI workflow so it uses the current test environment file and current checkout/setup-miniconda actions
- make the legacy `imolecule` GUI dependency optional so it does not block the base package build

## Why

The existing Anaconda.org package is from the 0.1.x series, while the repository is now on the 2.0 release-candidate line. The repository also lacked a current recipe and its existing CI referenced a deleted environment file.

## Validation

- built the Python wheel successfully with `pip wheel --no-deps --no-build-isolation`
- compiled the Python source with `compileall`
- parsed both GitHub Actions workflow files as YAML
- ran `git diff --check`

A full local `conda render` was attempted, but the local macOS sandbox denied the process semaphore operation used by `conda-build`. The new Ubuntu GitHub Actions job performs the authoritative conda dependency solve, build, and package tests.
